### PR TITLE
New version: Quac v0.1.3

### DIFF
--- a/Q/Quac/Versions.toml
+++ b/Q/Quac/Versions.toml
@@ -9,3 +9,6 @@ git-tree-sha1 = "64de9c3372d63761264420bb60b9670b4c714d8c"
 
 ["0.1.2"]
 git-tree-sha1 = "134de030de53b0cf3ba17eecfdfc412c7c53b5aa"
+
+["0.1.3"]
+git-tree-sha1 = "a474e5fcc37678bdf2d7292fd11bebb1f745ac06"


### PR DESCRIPTION
UUID: b9105292-1415-45cf-bff1-d6ccf71e6143
Repo: https://github.com/bsc-quantic/Quac.jl
Tree: a474e5fcc37678bdf2d7292fd11bebb1f745ac06

Registrator tree SHA: 34f32236bd52f16009955b1c9e34226d430f3524