### PR TITLE
New version: Quac v0.2.0

### DIFF
--- a/Q/Quac/Compat.toml
+++ b/Q/Quac/Compat.toml
@@ -9,3 +9,6 @@ SimpleWeightedGraphs = "1.2.0-1"
 
 ["0.1.2-0"]
 Requires = "1"
+
+["0.2-0"]
+LaTeXStrings = "1.3.0-1"

--- a/Q/Quac/Deps.toml
+++ b/Q/Quac/Deps.toml
@@ -9,3 +9,6 @@ SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 
 ["0.1.2-0"]
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+
+["0.2-0"]
+LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"

--- a/Q/Quac/Versions.toml
+++ b/Q/Quac/Versions.toml
@@ -12,3 +12,6 @@ git-tree-sha1 = "134de030de53b0cf3ba17eecfdfc412c7c53b5aa"
 
 ["0.1.3"]
 git-tree-sha1 = "a474e5fcc37678bdf2d7292fd11bebb1f745ac06"
+
+["0.2.0"]
+git-tree-sha1 = "f88326a879f09c0628f2b78b724da7771a02190d"


### PR DESCRIPTION
UUID: b9105292-1415-45cf-bff1-d6ccf71e6143
Repo: https://github.com/bsc-quantic/Quac.jl
Tree: f88326a879f09c0628f2b78b724da7771a02190d

Registrator tree SHA: 34f32236bd52f16009955b1c9e34226d430f3524